### PR TITLE
Added support for elliptic curve keys

### DIFF
--- a/setup.cpp
+++ b/setup.cpp
@@ -276,7 +276,7 @@ void setupDialog::on_toolButton_ssh_keyfile_clicked()
 
 			file_key.close();
 
-			if((key.startsWith("-----BEGIN RSA PRIVATE KEY-----\n") && key.endsWith("\n-----END RSA PRIVATE KEY-----\n")) || (key.startsWith("-----BEGIN OPENSSH PRIVATE KEY-----\n") && key.endsWith("\n-----END OPENSSH PRIVATE KEY-----\n")))
+			if((key.startsWith("-----BEGIN RSA PRIVATE KEY-----\n") && key.endsWith("\n-----END RSA PRIVATE KEY-----\n")) || (key.startsWith("-----BEGIN OPENSSH PRIVATE KEY-----\n") && key.endsWith("\n-----END OPENSSH PRIVATE KEY-----\n"))||(key.startsWith("-----BEGIN EC PRIVATE KEY-----\n") && key.endsWith("\n-----END EC PRIVATE KEY-----\n")))
 			{
 				lineEdit_ssh_keyfile->setText(file_key.fileName());
 


### PR DESCRIPTION
Added matching string for elliptic curve keys for SSH access. 
This works with Firmware 3.3.9 Build 001886 on a Roborock S5.